### PR TITLE
Change where game information is obscured

### DIFF
--- a/src/engine/api.go
+++ b/src/engine/api.go
@@ -48,7 +48,7 @@ func api_newGame(c *gin.Context) {
 	}
 
 	registerGame(newGame)
-	c.JSON(http.StatusOK, newGame.ObfuscateWord())
+	c.JSON(http.StatusOK, newGame)
 }
 
 // Returns the game struct with the specified ID as a JSON object.
@@ -56,7 +56,7 @@ func api_getGame(c *gin.Context) {
 	if game, err := getGame(c.Param("id")); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "could not find game"})
 	} else {
-		c.JSON(http.StatusOK, game.GetShareable())
+		c.JSON(http.StatusOK, game)
 	}
 }
 
@@ -103,7 +103,7 @@ func api_makeGuess(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, game.GetShareable())
+	c.JSON(http.StatusOK, game)
 }
 
 // Pings the gateway endpoint and forwards its response.

--- a/src/engine/api.go
+++ b/src/engine/api.go
@@ -20,7 +20,6 @@ func main() {
 	router.GET("/pingGateway", api_pingGateway)
 
 	// Endpoints for debugging
-	router.GET("/getGameExposed/:id", api_getGameExposed)
 	router.GET("/getAllGamesExposed", api_getAllGamesExposed)
 
 	router.Run("0.0.0.0:5001")
@@ -53,16 +52,6 @@ func api_newGame(c *gin.Context) {
 
 // Returns the game struct with the specified ID as a JSON object.
 func api_getGame(c *gin.Context) {
-	if game, err := getGame(c.Param("id")); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "could not find game"})
-	} else {
-		c.JSON(http.StatusOK, game)
-	}
-}
-
-// Returns the game struct with the specified ID as a JSON object.
-// Exposes the word, only used for debugging.
-func api_getGameExposed(c *gin.Context) {
 	if game, err := getGame(c.Param("id")); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "could not find game"})
 	} else {

--- a/src/gateway/gateway.go
+++ b/src/gateway/gateway.go
@@ -97,7 +97,7 @@ func api_newGame(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, newGame)
+	c.JSON(http.StatusOK, newGame.GetShareable())
 }
 
 // Calls the appropriate endpoint in the engine to retrieve an existing game
@@ -142,7 +142,7 @@ func api_getGame(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, currentGame)
+	c.JSON(http.StatusOK, currentGame.GetShareable())
 }
 
 // Calls the appropriate endpoint in the engine to make a guess
@@ -199,7 +199,7 @@ func api_makeGuess(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, currentGame)
+	c.JSON(http.StatusOK, currentGame.GetShareable())
 }
 
 func api_newUser(c *gin.Context) {


### PR DESCRIPTION
Used to be obscured engine -> gateway but is now obscured gateway -> frontend.

This way, the engine can communicate the word to the online container as needed.