### PR TITLE
Upgrade Node Image to node:20.5.1-bookworm-slim

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -60,7 +60,7 @@ RUN go build -o cli-executable
 CMD [ "./cli-executable" ]
 
 # Front End
-FROM node:16 AS frontend
+FROM node:20.5.1-bookworm-slim AS frontend
 
 WORKDIR /src/frontend
 


### PR DESCRIPTION
Node 16 is deprecated, so I did some research, and this image seems to be the most lightweight and secure image of node out there. It also is on Node version 20.5.1, which is being supported currently as Node 20.9.0 is the most recent stable version. 